### PR TITLE
PropTypes was moved to prop-types in React v15.5

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,11 +9,14 @@ let {
 let styles = require('./styles');
 let LoadingIndicator = require('./loader');
 
-const SleekLoadingIndicator = React.createClass({
+let PropTypes = require('prop-types');
+let createReactClass = require('create-react-class');
+
+const SleekLoadingIndicator = createReactClass({
 
   propTypes: {
-    text: React.PropTypes.string,
-    loading: React.PropTypes.bool,
+    text: PropTypes.string,
+    loading: PropTypes.bool,
   },
 
   getDefaultProps() {

--- a/loader.js
+++ b/loader.js
@@ -9,7 +9,10 @@ let {
 } = require('react-native');
 let styles = require('./styles');
 
-module.exports = React.createClass({
+let PropTypes = require('prop-types');
+let createReactClass = require('create-react-class');
+
+module.exports = createReactClass({
    render() {
       return (
          <View style={styles.loadingContainer}>


### PR DESCRIPTION
PropTypes was moved to prop-types in React v15.5
React.createClass was removed in React v16.0

These changes allow this component to render in RN 0.56.0